### PR TITLE
Limit jekyll version (latest breaks this role)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,10 @@
   become: yes
   gem:
     name: jekyll
+    # 3.5.0 breaks this role
+    # 3.4.4 causes a version conflict with another package (2017-06-20)
+    # TODO: see if the conflicting package has been fixed
+    version: 3.4.3
     state: present
     user_install: no
     include_doc: no


### PR DESCRIPTION
- 3.5.0 breaks this role
- 3.4.4 causes a mysterious version conflict
- 3.4.3 seems to work

Tag: 1.1.1