### PR TITLE
Prepend path in the bundle install handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,6 +6,8 @@
   become_user: "{{ jekyll_build_owner }}"
   environment:
     NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
+    # Ensure that bundle is on the PATH
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   command: bundle install
   args:
     chdir: "{{jekyll_build_sourcedir}}"


### PR DESCRIPTION
Fixes #3 - see also https://github.com/openmicroscopy/infrastructure/pull/283

In addition to Travis, this can be tested using `molecule test --driver vagrant`