### PR TITLE
Also notify the bundle install handler when forcing a rebuild

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,5 +66,7 @@
 
 -  debug:
      msg: "Force jekyll rebuild: {{ jekyll_build_force_rebuild }}"
-   notify: jekyll build
+   notify:
+   - update bundle
+   - jekyll build
    changed_when: jekyll_build_force_rebuild


### PR DESCRIPTION
Noticed while testing this role in a more complex playbook. If the first execution of the playbook fails after the jekyll_build tasks but before the handlers are called the bundle install step is skipped.
At the following execution, since the clone step is unchanged, the jekyll build step will fail on a force rebuild with a missing dependencies.

This bug fix change modifies the last task to notify both handlers when setting
jekyll_build_force_rebuild to True.