### PR TITLE
Use bundler and Gemfile{.lock} to freeze dependency versions

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'jekyll'

--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.4.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.14.0)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+
+BUNDLED WITH
+   1.15.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,7 @@
   become: yes
   bundler:
     chdir: /opt/jekyll-build
+    executable: /usr/local/bin/bundler
     state: present
 
 - name: jekyll | create site root directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,9 @@
     name: bundler
     state: present
     user_install: no
+    # bundler adds the version to Gemfile.lock, so to avoid an idempotence
+    # error the versions must match
+    version: 1.15.4
 
 - name: jekyll | install pkg-config
   become: yes
@@ -28,17 +31,27 @@
     state: present
     user_install: no
 
+- name: jekyll | create jekyll install directory
+  become: yes
+  file:
+    path: /opt/jekyll-build/
+    state: directory
+
+- name: jekyll | copy gemfiles
+  become: yes
+  copy:
+    dest: /opt/jekyll-build/{{ item }}
+    force: yes
+    src: "{{ item }}"
+  with_items:
+  - Gemfile
+  - Gemfile.lock
+
 - name: jekyll | install jekyll
   become: yes
-  gem:
-    name: jekyll
-    # 3.5.0 breaks this role
-    # 3.4.4 causes a version conflict with another package (2017-06-20)
-    # TODO: see if the conflicting package has been fixed
-    version: 3.4.3
+  bundler:
+    chdir: /opt/jekyll-build
     state: present
-    user_install: no
-    include_doc: no
 
 - name: jekyll | create site root directory
   become: yes


### PR DESCRIPTION
Closes #8 

The Gemfile.lock versions are taken from the installed working version on IDR-0.4.3 (Aug 11 2017).