### PR TITLE
Set default value for jekyll_build_git_branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Install Jekyll and setup a site.
 Dependencies
 ------------
 
-This role requires `git` and therefore includes `versioncontrol-utils` as a dependency.
+This role requires `git` and therefore includes
+`openmicroscopy.versioncontrol-utils` as a dependency.
 
 
 Role Variables
@@ -29,7 +30,7 @@ Optional variables:
 
 - `jekyll_build_root`: The destination directory for the Jekyll output
 - `jekyll_build_owner`, `jekyll_build_group`: The system owner and group of `jekyll_build_sourcedir` and `jekyll_build_root`, default `root:root`
-- `jekyll_build_git_branch`: Git branch
+- `jekyll_build_git_branch`: The name of the git branch to clone, default `master`
 - `jekyll_build_force_git`: Remove modified files in the git repository, default `False`
 - `jekyll_build_baseurl`: Prefix for the Jekyll site
 - `jekyll_build_config`: A list of configuration files to use for building

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,9 @@ jekyll_build_sourcedir: "/home/{{ jekyll_build_owner }}/{{ jekyll_build_name }}"
 jekyll_build_root: /var/www/{{ jekyll_build_name }}/html
 # Reguired: URL to git repository
 #jekyll_build_git_repo:
-# Optional, default omit
-#jekyll_build_git_branch:
+
+# Default branch
+jekyll_build_git_branch: master
 jekyll_build_baseurl: ""
 jekyll_build_config: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
   become_user: "{{ jekyll_build_owner }}"
   git:
     repo: "{{ jekyll_build_git_repo }}"
-    version: "{{ jekyll_build_git_branch | default(omit) }}"
+    version: "{{ jekyll_build_git_branch }}"
     dest: "{{ jekyll_build_sourcedir }}"
     force: "{{ jekyll_build_force_git }}"
   notify:


### PR DESCRIPTION
See https://github.com/ansible/ansible/issues/30780

A change was introduced in Ansible 2.4.0.0 to resolve possible ambiguities. Rather than using `HEAD`, this fixes the `jekyll-build` role to default to `master` instead.

Tests should pass and this commit should have no impact on our usages of the role since `master` was the default branch of the repositories. Since this role is potentially broken on Ansible 2.4 if the consumer playbook is not overriding the branch variable, proposing as `1.3.1`.